### PR TITLE
(master) configure.ac: replace deprecated AC_PROG_LIBTOOL by LT_INIT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AM_INIT_AUTOMAKE([foreign dist-xz])
 
 # Initialize libtool
 AC_DISABLE_STATIC
-AC_PROG_LIBTOOL
+LT_INIT
 
 AH_TOP([#include "xorg-server.h"])
 


### PR DESCRIPTION
Signed-off-by: Enrico Weigelt, metux IT consult <info@metux.net>
